### PR TITLE
Update package name from identique-mcp to identique_mcp in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ You can run the MCP server directly from the repository using uv:
 
 ```bash
 # Run the server directly
-uv run --with git+https://github.com/AngusHsu/identique_mcp.git identique-mcp
+uv run --with git+https://github.com/AngusHsu/identique_mcp.git identique_mcp
 
 # Or clone and run locally
 git clone https://github.com/AngusHsu/identique_mcp.git
 cd identique_mcp
-uv run identique-mcp
+uv run identique_mcp
 ```
 
 ### Using pip
@@ -47,7 +47,7 @@ uv run identique-mcp
 pip install git+https://github.com/AngusHsu/identique_mcp.git
 
 # Run the server
-identique-mcp
+identique_mcp
 ```
 
 ### Development Setup
@@ -56,7 +56,7 @@ identique-mcp
 git clone https://github.com/AngusHsu/identique_mcp.git
 cd identique_mcp
 uv sync
-uv run identique-mcp
+uv run identique_mcp
 ```
 
 ## MCP Client Configuration
@@ -76,7 +76,7 @@ Add to your `claude_desktop_config.json`:
         "run",
         "--with",
         "git+https://github.com/AngusHsu/identique_mcp.git",
-        "identique-mcp"
+        "identique_mcp"
       ]
     }
   }
@@ -89,7 +89,7 @@ Or if you have it installed locally:
 {
   "mcpServers": {
     "identique": {
-      "command": "identique-mcp"
+      "command": "identique_mcp"
     }
   }
 }


### PR DESCRIPTION
This PR updates all instances of `identique-mcp` to `identique_mcp` in the README file to match the package name in `pyproject.toml`.

## Changes Made:
- Updated command line references from `identique-mcp` to `identique_mcp`
- Updated all installation and usage examples to use the underscore version
- Updated MCP client configuration examples

This ensures consistency between the package name and the documentation.